### PR TITLE
refactor: rename UI component classes and update CSS custom properties

### DIFF
--- a/index.html
+++ b/index.html
@@ -135,13 +135,13 @@
             "
           >
             <li>
-              <a class="scope ui-button" href="#installation">
+              <a class="scope button" href="#installation">
                 今すぐ使い始める
               </a>
             </li>
             <li>
               <a
-                class="scope ui-github-button"
+                class="scope github-button"
                 href="https://github.com/tak-dcxi/kiso.css/"
                 lang="en"
                 translate="no"
@@ -170,20 +170,20 @@
               background-color: var(--background--lighten);
             }
 
-            @property --site-header--padding-block-min {
+            @property --site-header--min-padding-block {
               syntax: "<length>";
               inherits: false;
               initial-value: 0;
             }
 
             ._body {
-              --site-header--padding-block-min: 3rlh;
+              --site-header--min-padding-block: 3rlh;
 
               padding-block: clamp(
-                var(--site-header--padding-block-min),
+                var(--site-header--min-padding-block),
                 tan(
                     atan2(
-                      var(--site-header--padding-block-min),
+                      var(--site-header--min-padding-block),
                       var(--art-board--min-width) * 1px
                     )
                   ) * 100cqi,
@@ -199,7 +199,7 @@
     <main class="full-bleed" style="--full-bleed--row-gap: 3rlh">
       <section id="features" class="scope ui-section">
         <div class="flow" style="--flow--space: 2rlh">
-          <h2 class="scope ui-heading | -fluid-text--lg -text-center">特徴</h2>
+          <h2 class="scope heading | -fluid-text--lg -text-center">特徴</h2>
           <div class="scope features-cards">
             <div
               class="_body | grid"
@@ -374,13 +374,13 @@
       </section>
 
       <section id="installation" class="flow" style="--flow--space: 2rlh">
-        <h2 class="scope ui-heading | -fluid-text--lg -text-center">
+        <h2 class="scope heading | -fluid-text--lg -text-center">
           インストール
         </h2>
         <section>
           <div class="flow" style="--flow--space: 1rlh">
             <h3 class="-fluid-text--md">npm / yarn</h3>
-            <pre class="scope ui-code">
+            <pre class="scope code">
               <code>npm install kiso.css</code>
               <code># or</code>
               <code>yarn add kiso.css</code>
@@ -391,7 +391,7 @@
         <section>
           <div class="flow" style="--flow--space: 1rlh">
             <h3 class="-fluid-text--md">CDN</h3>
-            <pre class="scope ui-code">
+            <pre class="scope code">
               <code>&lt;link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/kiso.css@latest/kiso.css"&gt;</code>
             </pre>
           </div>
@@ -402,7 +402,7 @@
             <h3 class="-fluid-text--md">ダウンロード</h3>
             <p class="-hanging">
               <a
-                class="ui-inline-link"
+                class="inline-link"
                 href="https://tak-dcxi.github.io/kiso.css/kiso.css"
                 >GitHub</a
               >から直接ダウンロードして、プロジェクトに含めることもできます。
@@ -426,7 +426,7 @@
         >
           <li>
             <a
-              class="ui-inline-link"
+              class="inline-link"
               href="https://github.com/tak-dcxi/kiso.css/"
               lang="en"
               translate="no"
@@ -435,7 +435,7 @@
           </li>
           <li>
             <a
-              class="ui-inline-link"
+              class="inline-link"
               href="https://www.npmjs.com/package/kiso.css"
               lang="en"
               translate="no"
@@ -444,7 +444,7 @@
           </li>
           <li>
             <a
-              class="ui-inline-link"
+              class="inline-link"
               href="https://github.com/tak-dcxi/kiso.css/blob/main/LICENSE"
               lang="en"
               >MIT License</a
@@ -455,7 +455,7 @@
           <small class="-fluid-text--sm">
             © 2026 TAK (
             <a
-              class="ui-inline-link"
+              class="inline-link"
               href="https://www.tak-dcxi.com/"
               target="_blank"
             >
@@ -478,20 +478,20 @@
               }
             }
 
-            @property --site-footer--padding-block-min {
+            @property --site-footer--min-padding-block {
               syntax: "<length>";
               inherits: false;
               initial-value: 0;
             }
 
             ._body {
-              --site-footer--padding-block-min: 2rlh;
+              --site-footer--min-padding-block: 2rlh;
 
               padding-block: clamp(
-                var(--site-footer--padding-block-min),
+                var(--site-footer--min-padding-block),
                 tan(
                     atan2(
-                      var(--site-footer--padding-block-min),
+                      var(--site-footer--min-padding-block),
                       var(--art-board--min-width) * 1px
                     )
                   ) * 100cqi,
@@ -507,20 +507,20 @@
     <style>
       @layer pages {
         @scope to (.scope) {
-          @property --home-page--padding-block-min {
+          @property --home-page--min-padding-block {
             syntax: "<length>";
             inherits: false;
             initial-value: 0;
           }
 
           main {
-            --home-page--padding-block-min: 3rlh;
+            --home-page--min-padding-block: 3rlh;
 
             padding-block: clamp(
-              var(--home-page--padding-block-min),
+              var(--home-page--min-padding-block),
               tan(
                   atan2(
-                    var(--home-page--padding-block-min),
+                    var(--home-page--min-padding-block),
                     var(--art-board--min-width) * 1px
                   )
                 ) * 100svi,

--- a/kiso.css
+++ b/kiso.css
@@ -186,8 +186,9 @@
   * Set a monospace font family referencing Tailwind.
   * @see https://tailwindcss.com/docs/font-family
   */
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
-    "Liberation Mono", "Courier New", monospace;
+  font-family:
+    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+    "Courier New", monospace;
 
   /* Font feature settings can have adverse effects on monospaced fonts, so their values are explicitly set to `initial` to prevent inheritance. */
   font-feature-settings: initial;
@@ -246,13 +247,15 @@
 /* ======================================================
 //  MARK: Links
 // ====================================================== */
-:where(a) {
-  /*
-  * The default `color` from the UA stylesheet is rarely used as is, so it's reset to allow inheritance.
-  * In Firefox on iOS, the user agent stylesheet’s text color is applied even when the text is not a link.
-  * @see https://github.com/darkreader/darkreader/issues/9836
-  */
-  color: unset;
+@media (forced-colors: none) {
+  :where(a) {
+    /*
+    * The default `color` from the UA stylesheet is rarely used as is, so it's reset to allow inheritance.
+    * In Firefox on iOS, the user agent stylesheet’s text color is applied even when the text is not a link.
+    * @see https://github.com/darkreader/darkreader/issues/9836
+    */
+    color: unset;
+  }
 }
 
 :where(a:any-link) {
@@ -329,10 +332,16 @@
   /* These styles specified in the UA stylesheet are often unnecessary, so they are reset to allow for inheritance. */
   border-color: unset;
   border-radius: unset;
-  color: unset;
   font: unset;
   letter-spacing: unset;
   text-align: unset;
+}
+
+@media (forced-colors: none) {
+  :where(button, input, select, textarea),
+  ::file-selector-button {
+    color: unset;
+  }
 }
 
 :where(input:is([type="radio" i], [type="checkbox" i])) {
@@ -358,13 +367,13 @@
 }
 
 :where(
-    input:is(
-        [type="tel" i],
-        [type="url" i],
-        [type="email" i],
-        [type="number" i]
-      ):not(:placeholder-shown)
-  ) {
+  input:is(
+      [type="tel" i],
+      [type="url" i],
+      [type="email" i],
+      [type="number" i]
+    ):not(:placeholder-shown)
+) {
   /*
   * Certain input types need to maintain left alignment even in right-to-left (RTL) languages.
   * However, this only applies when the value is not empty, as the placeholder should be right-aligned.
@@ -382,30 +391,30 @@
 }
 
 :where(
-    input:not([type="button" i], [type="submit" i], [type="reset" i]),
-    textarea,
-    [contenteditable]
-  ) {
+  input:not([type="button" i], [type="submit" i], [type="reset" i]),
+  textarea,
+  [contenteditable]
+) {
   /* Set to `no-autospace` because `text-autospace` can insert spaces during input, potentially causing erratic behavior. */
   text-autospace: no-autospace;
 }
 
 :where(
-    button,
-    input:is([type="button" i], [type="submit" i], [type="reset" i])
-  ),
+  button,
+  input:is([type="button" i], [type="submit" i], [type="reset" i])
+),
 ::file-selector-button {
   /* The `background-color` specified in the User Agent (UA) stylesheet is often unnecessary, so it is reset here. */
   background-color: unset;
 }
 
 :where(
-    button,
-    input:is([type="button" i], [type="submit" i], [type="reset" i]),
-    [role="tab" i],
-    [role="button" i],
-    [role="option" i]
-  ),
+  button,
+  input:is([type="button" i], [type="submit" i], [type="reset" i]),
+  [role="tab" i],
+  [role="button" i],
+  [role="option" i]
+),
 ::file-selector-button {
   /*
   * On iOS, double-tapping a button can cause zooming, which harms usability.
@@ -416,20 +425,20 @@
 }
 
 :where(
-    button:enabled,
-    label[for],
-    select:enabled,
-    input:is(
-        [type="button" i],
-        [type="submit" i],
-        [type="reset" i],
-        [type="radio" i],
-        [type="checkbox" i]
-      ):enabled,
-    [role="tab" i],
-    [role="button" i],
-    [role="option" i]
-  ),
+  button:enabled,
+  label[for],
+  select:enabled,
+  input:is(
+      [type="button" i],
+      [type="submit" i],
+      [type="reset" i],
+      [type="radio" i],
+      [type="checkbox" i]
+    ):enabled,
+  [role="tab" i],
+  [role="button" i],
+  [role="option" i]
+),
 :where(:enabled)::file-selector-button {
   /* Indicate clickable elements with a pointer cursor. */
   cursor: pointer;

--- a/lp/style.css
+++ b/lp/style.css
@@ -1,4 +1,4 @@
-@layer tokens, reset, base, composition, pages, features, affordance, utilities;
+@layer tokens, reset, base, vendors, composition, pages, features, affordance, utilities;
 
 @import url("../kiso.css") layer(reset);
 
@@ -116,12 +116,12 @@
   }
 
   :where(:focus-visible) {
-    --_ring--width: 3px;
-    --_ring--offset: 3px;
+    --_ring-width: 3px;
+    --_ring-offset: 3px;
 
-    box-shadow: 0 0 0 calc(var(--_ring--offset) + var(--_ring--width)) Canvas !important;
-    outline: var(--_ring--width) solid CanvasText;
-    outline-offset: var(--_ring--offset);
+    box-shadow: 0 0 0 calc(var(--_ring-offset) + var(--_ring-width)) Canvas !important;
+    outline: var(--_ring-width) solid CanvasText;
+    outline-offset: var(--_ring-offset);
   }
 
   @property --gradient-alpha {
@@ -132,100 +132,137 @@
 }
 
 @layer composition {
-  .flow {
-    display: block flow-root;
+  @scope (.flow) {
+    :scope {
+      display: block flow-root;
 
-    & > * + * {
-      margin-block-start: var(--flow--space, 1.5rlh);
+      & > * + * {
+        margin-block-start: var(--flow--space, 1.5rlh);
+      }
     }
   }
 
-  .grid {
-    --_c--mode: var(--grid--mode, auto-fit);
-    --_c--row-gap: var(--grid--row-gap, 1.5rem);
-    --_c--column-gap: var(--grid--column-gap, 1.5rem);
-    --_c--column-max-count: var(--grid--column-max-count, 5);
-    --_c--column-min-width: var(--grid--column-min-width, 20rem);
+  @scope (.grid) {
+    :scope {
+      --_c--mode: var(--grid--mode, auto-fit);
+      --_c--column-max-count: var(--grid--column-max-count, 5);
+      --_c--column-min-width: var(--grid--column-min-width, 20rem);
+      --_c--column-preferred-width: calc(
+        (100% - var(--_c--column-gap) * (var(--_c--column-max-count) - 1)) /
+          var(--_c--column-max-count)
+      );
+      --_c--column-width: min(
+        100%,
+        max(var(--_c--column-min-width), var(--_c--column-preferred-width))
+      );
+      --_c--row-gap: var(--grid--row-gap, 1.5rem);
+      --_c--column-gap: var(--grid--column-gap, 1.5rem);
 
-    /* コンテナの横幅からギャップの合計値を引いたものをn等分する */
-    --_c--column-width-calculated: calc(
-      (100% - var(--_c--column-gap) * (var(--_c--column-max-count) - 1)) /
-        var(--_c--column-max-count)
-    );
-
-    /* 最終的に適用される列の幅。理想の幅と最小幅を比較し、大きい方を採用します。*/
-    --_c--column-width: min(
-      100%,
-      max(var(--_c--column-min-width), var(--_c--column-width-calculated))
-    );
-
-    display: block grid;
-    grid-template-columns: repeat(
-      var(--_c--mode),
-      minmax(var(--_c--column-width), 1fr)
-    );
-    gap: var(--_c--row-gap) var(--_c--column-gap);
+      display: block grid;
+      grid-template-columns: repeat(
+        var(--_c--mode),
+        minmax(var(--_c--column-width), 1fr)
+      );
+      gap: var(--_c--row-gap) var(--_c--column-gap);
+    }
   }
 
-  .cluster {
-    --_c--row-gap: var(--cluster--row-gap, 1rem);
-    --_c--column-gap: var(--cluster--column-gap, 1rem);
-    --_c--main-alignment: var(--cluster--main-alignment, normal);
-    --_c--cross-alignment: var(--cluster--cross-alignment, normal);
+  @scope (.cluster) {
+    :scope {
+      --_c--row-gap: var(--cluster--row-gap, 1rem);
+      --_c--column-gap: var(--cluster--column-gap, 1rem);
+      --_c--main-alignment: var(--cluster--main-alignment, normal);
+      --_c--cross-alignment: var(--cluster--cross-alignment, normal);
 
-    display: block flex;
-    flex-wrap: wrap;
-    gap: var(--_c--row-gap) var(--_c--column-gap);
-    justify-content: var(--_c--main-alignment);
-    align-items: var(--_c--cross-alignment);
+      display: block flex;
+      flex-wrap: wrap;
+      gap: var(--_c--row-gap) var(--_c--column-gap);
+      justify-content: var(--_c--main-alignment);
+      align-items: var(--_c--cross-alignment);
+    }
   }
 
-  .full-bleed {
-    --_c--content-max-width: var(--full-bleed--content-max-width, 64rem);
-    --_c--breakout-max-width: var(
-      --full-bleed--breakout-max-width,
-      calc(var(--_c--content-max-width) + 10rem * 2)
-    );
-    --_c--gutter: var(--full-bleed--gutter, max(16px, 5%));
-    --_c--row-gap: var(--full-bleed--row-gap, 0px);
-    --_c--breakout-area-width: calc(
-      (var(--_c--breakout-max-width) - var(--_c--content-max-width)) / 2
-    );
-    --_c--content-area-width: min(
-      var(--_c--content-max-width),
-      100% - var(--_c--gutter) * 2
-    );
+  @scope (.sidebar) {
+    :scope {
+      --_c--main-min-width: var(--sidebar--main-min-width, 30rem);
+      --_c--side-width: var(--sidebar--side-width, 20rem);
+      --_c--row-gap: var(--sidebar--row-gap, 32px);
+      --_c--column-gap: var(--sidebar--column-gap, 32px);
 
-    display: block grid;
-    grid-template-columns:
-      [--full-start]
-      minmax(var(--_c--gutter), 1fr)
-      [--breakout-start]
-      minmax(0, var(--_c--breakout-area-width))
-      [--content-start]
-      var(--_c--content-area-width)
-      [--content-end]
-      minmax(0, var(--_c--breakout-area-width))
-      [--breakout-end]
-      minmax(var(--_c--gutter), 1fr)
-      [--full-end];
-    row-gap: var(--_c--row-gap);
-    align-content: start;
+      display: block flex;
+      flex-wrap: wrap;
+      gap: var(--_c--row-gap) var(--_c--column-gap);
 
-    & > * {
-      grid-column: var(--full-bleed--column, --content);
+      & > ._main-column {
+        flex-grow: 9999;
+        flex-basis: calc(
+          var(--_c--main-min-width) *
+            sign(100% - (var(--_c--side-width) + var(--_c--column-gap)))
+        );
+      }
+
+      & > ._side-column {
+        flex-grow: 1;
+        flex-basis: var(--_c--side-width);
+      }
+    }
+  }
+
+  @scope (.full-bleed) {
+    :scope {
+      --_c--content-max-width: var(--full-bleed--content-max-width, 64rem);
+      --_c--breakout-max-width: var(
+        --full-bleed--breakout-max-width,
+        calc(var(--_c--content-max-width) + 10rem * 2)
+      );
+      --_c--gutter: var(--full-bleed--gutter, max(16px, 5%));
+      --_c--row-gap: var(--full-bleed--row-gap, 0px);
+      --_c--breakout-area-width: calc(
+        (var(--_c--breakout-max-width) - var(--_c--content-max-width)) / 2
+      );
+      --_c--content-area-width: min(
+        var(--_c--content-max-width),
+        100% - var(--_c--gutter) * 2
+      );
+
+      display: block grid;
+      grid-template-columns:
+        [--full-start]
+        minmax(var(--_c--gutter), 1fr)
+        [--breakout-start]
+        minmax(0, var(--_c--breakout-area-width))
+        [--content-start]
+        var(--_c--content-area-width)
+        [--content-end]
+        minmax(0, var(--_c--breakout-area-width))
+        [--breakout-end]
+        minmax(var(--_c--gutter), 1fr)
+        [--full-end];
+      row-gap: var(--_c--row-gap);
+      align-content: start;
+
+      & > * {
+        grid-column: --content;
+      }
+
+      & > ._breakout-column {
+        grid-column: --breakout;
+      }
+
+      & > ._full-column {
+        grid-column: --full;
+      }
     }
   }
 }
 
 @layer affordance {
-  @scope (.ui-button) {
+  @scope (.button) {
     :scope {
       --_accent--primary: #8474fe;
       --_accent--secondary: #4d36d0;
       --_hocus--on: ;
       --_hocus--off: initial;
-
       --gradient-alpha: var(--_hocus--on, 0%) var(--_hocus--off, 100%);
 
       display: inline flow-root;
@@ -266,7 +303,7 @@
     }
   }
 
-  @scope (.ui-heading) {
+  @scope (.heading) {
     :scope {
       &::after {
         content: "";
@@ -279,7 +316,7 @@
     }
   }
 
-  @scope (.ui-code) {
+  @scope (.code) {
     :scope {
       display: block grid;
       padding-block: 1rlh;
@@ -295,7 +332,7 @@
     }
   }
 
-  @scope (.ui-github-button) {
+  @scope (.github-button) {
     :scope {
       --_background--default: var(--color--darkest);
       --_background--hocus: oklch(from var(--_background--default) 30% c h);
@@ -341,22 +378,27 @@
     }
   }
 
-  @scope (.ui-inline-link) {
+  @scope (.inline-link) {
     :scope {
       --_foreground: var(--inline-link--foreground, var(--foreground--primary));
+      --_hocus--on: ;
+      --_hocus--off: initial;
 
       color: var(--_foreground);
       text-decoration-line: revert;
+      text-decoration-color: var(--_hocus--on, transparent);
       transition-duration: 300ms;
       transition-property: text-decoration-color;
 
       &:focus-visible {
-        text-decoration-color: transparent;
+        --_hocus--on: initial;
+        --_hocus--off: ;
       }
 
       &:any-link:hover {
         @media (any-hover) {
-          text-decoration-color: transparent;
+          --_hocus--on: initial;
+          --_hocus--off: ;
         }
       }
     }


### PR DESCRIPTION
- Rename component classes by removing 'ui-' prefix (ui-button → button, ui-heading → heading, ui-code → code, ui-github-button → github-button, ui-inline-link → inline-link)
- Rename CSS custom properties to use 'min-' prefix instead of '-min' suffix for consistency (e.g., --padding-block-min → --min-padding-block)
- Add forced-colors media query support for link and form element colors
- Refactor composition layer to use @scope for better encapsulation (.flow, .grid, .cluster, .sidebar, .full-bleed)
- Add 'vendors' layer to layer order
- Update focus ring variable names (--_ring--width → --_ring-width, --_ring--offset → --_ring-offset)
- Minor code formatting improvements

🤖 Generated with [Claude Code](https://claude.com/claude-code)